### PR TITLE
Make log format configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ MONGODB_URI=mongodb://mongodb:27017/
 # Configure log level
 LOGGING_LEVEL=info
 
+# Configure log format
+LOGGING_FORMAT="%(asctime)s - %(levelname)s - %(message)s"
+
 # Specify Mongo Database - Optional. Defaults to "LibreChat"
 MONGODB_DATABASE=librechat
 ```

--- a/metrics.py
+++ b/metrics.py
@@ -15,8 +15,10 @@ load_dotenv()
 
 # Set up logging
 loglevel = os.getenv("LOGGING_LEVEL", "info").upper()
-logging.basicConfig(level=loglevel)
+logformat = os.getenv("LOGGING_FORMAT", "%(asctime)s - %(levelname)s - %(message)s")
+logging.basicConfig(format=logformat, level=loglevel)
 logger = logging.getLogger(__name__)
+logger.debug("Set log level to %s", logging.getLevelName(logger.getEffectiveLevel()))
 
 
 class LibreChatMetricsCollector(Collector):


### PR DESCRIPTION
This patch makes the logging format configurable using the environment variable `LOGGING_FORMAT`:

    LOGGING_FORMAT="%(asctime)s: %(message)s"