### PR TITLE
Use Twisted as web server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 prometheus-client
 pymongo
 python-dotenv
+Twisted


### PR DESCRIPTION
This patch switches to using twisted as web server. This makes signal handling quite a bit easier, while allowing for more control about what is being served and how it is served.

Mostly, though, this is a preparation for service additional statistics data later on since this allows us to easily add new endpoints for serving data.