### PR TITLE
[Prototype] Daily/Weekly statistics for Grafana Infinity plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ metrics:
   environment:
     - MONGODB_URI=mongodb://mongodb:27017/
     - LOGGING_LEVEL=info
+    - TZ=Europe/Berlin
   restart: unless-stopped
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 prometheus-client
 pymongo
 python-dotenv
+Twisted


### PR DESCRIPTION
This is an experimental extension for generating daily and weekly usage
statistics to be visualized using Grafana's Infinity plugin.

Currently missing are:

- Store generated statistics data
  - Should improve boot performance quite a bit
  - Handles users deleting old messages
- Simplify update mechanism
  - Only generate what's necessary
  - Put update code in a single function
- Handle monthly and yearly statistics
- Handle `from` and `to` parameters

This includes #17

![Screenshot from 2025-01-26 23-57-09](https://github.com/user-attachments/assets/167ef5f1-fce2-442b-8f09-95bb5317b0bb)
*This is how something like this could look in Grafana*

```json
{
  "daily": [
    {
      "date": "2025-01-15",
      "user": 2
    },
    {
      "date": "2025-01-16",
      "user": 0
    },
    {
      "date": "2025-01-17",
      "user": 0
    },
    {
      "date": "2025-01-18",
      "user": 0
    },
    {
      "date": "2025-01-19",
      "user": 0
    },
    {
      "date": "2025-01-20",
      "user": 0
    },
    {
      "date": "2025-01-21",
      "user": 0
    },
    {
      "date": "2025-01-22",
      "user": 0
    },
    {
      "date": "2025-01-23",
      "user": 0
    },
    {
      "date": "2025-01-24",
      "user": 0
    },
    {
      "date": "2025-01-25",
      "user": 0
    }
  ],
  "weekly": [
    {
      "date": "2025-01-13",
      "user": 2
    }
  ]
}
```
*This is more or less how the output looks like*