### PR TITLE
Make DB name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ MONGODB_URI=mongodb://mongodb:27017/
 
 # Configure log level
 LOGGING_LEVEL=info
+
+# Specify Mongo Database - Optional. Defaults to "LibreChat"
+MONGODB_DATABASE=librechat
 ```
 
 ### 4. Run the Script

--- a/metrics.py
+++ b/metrics.py
@@ -28,7 +28,7 @@ class LibreChatMetricsCollector(Collector):
         Initialize the MongoDB client and set up initial state.
         """
         self.client = MongoClient(mongodb_uri)
-        self.db = self.client["LibreChat"]
+        self.db = self.client[os.getenv("MONGODB_DATABASE", "LibreChat")]
         self.messages_collection = self.db["messages"]
 
     def collect(self):


### PR DESCRIPTION
Database can be something other then "LibreChat" depending on how you configured it (also it's case-sensitive).  Maybe it should just be specified in MONGODB_URI but this is a fix that requires less changes