### PR TITLE
Fix/metrics typo and type

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -50,7 +50,7 @@ class LibreChatMetricsCollector(Collector):
         yield from self.collect_active_user_count()
         yield from self.collect_active_conversation_count()
         yield from self.collect_uploaded_file_count()
-        yield from self.collect_registerd_user_count()
+        yield from self.collect_registered_user_count()
         # Adding new time-based metrics
         yield from self.collect_daily_unique_users()
         yield from self.collect_weekly_unique_users()
@@ -328,7 +328,7 @@ class LibreChatMetricsCollector(Collector):
         except Exception as e:
             logger.exception("Error collecting uploaded files: %s", e)
 
-    def collect_registerd_user_count(self):
+    def collect_registered_user_count(self):
         """
         Collect number of registered users.
         """

--- a/metrics.py
+++ b/metrics.py
@@ -335,7 +335,7 @@ class LibreChatMetricsCollector(Collector):
         try:
             user_count = self.db["users"].estimated_document_count()
             logger.debug("Number of registered users: %s", user_count)
-            yield CounterMetricFamily(
+            yield GaugeMetricFamily(
                 "librechat_registered_users_total",
                 "Number of registered users",
                 value=user_count,


### PR DESCRIPTION
1.  Fixes a typo in the `collect_registered_user_count` method name.
2.  Corrects the metric type for `librechat_registered_users_total` from `CounterMetricFamily` to `GaugeMetricFamily`. This change reflects that the total number of registered users can decrease if users are deleted from the system, making a Gauge a more appropriate representation.
3.  Adds new metrics to track recent error rates:
    *   `librechat_error_messages_5m`: Total number of error messages in the last 5 minutes.
    *   `librechat_errors_per_model_5m`: Number of error messages per model in the last 5 minutes.
    *   The new 5-minute error metrics provide better visibility into recent error spikes. This allows for quicker identification of issues that might be obscured by long-term total error counts, especially if one model generates a large volume of errors, making it hard to see trends for other models.