### PR TITLE
fix: rename endpoint label to api_endpoint to avoid Prometheus conflict

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -1513,7 +1513,7 @@ class LibreChatMetricsCollector(Collector):
             metric = GaugeMetricFamily(
                 "librechat_tool_calls_per_endpoint",
                 "Number of tool calls per endpoint and tool combination",
-                labels=["endpoint", "tool_name"],
+                labels=["api_endpoint", "tool_name"],
             )
 
             for (endpoint, tool), count in data.items():


### PR DESCRIPTION
Prometheus injects a default `endpoint` label (typically "http") from the scrape config, which overwrites the exporter's `endpoint` label on the librechat_tool_calls_per_endpoint metric. Renaming to `api_endpoint` avoids this collision.

Closes #48