### PR TITLE
chore: post-merge polish for historic-analysis refactor

### DIFF
--- a/historic-analysis/export_metrics.py
+++ b/historic-analysis/export_metrics.py
@@ -437,11 +437,11 @@ class MetricsCalculator:
                     user_msg_id = message.get('messageId')
                     user = message.get('user')
                     ai_responses = self._ai_responses_by_parent.get(user_msg_id, ())
-                    
+
                     for ai_msg in ai_responses:
                         tokens_by_model[ai_msg['model']]['input'] += token_count
-                        if user and ai_responses:
-                            tokens_by_user[user]['input'] += token_count
+                    if user:
+                        tokens_by_user[user]['input'] += token_count * len(ai_responses)
 
                 elif message.get('model'):
                     tokens_by_model[model_name]['output'] += token_count

--- a/historic-analysis/mariadb-init/init.sql
+++ b/historic-analysis/mariadb-init/init.sql
@@ -1,4 +1,8 @@
--- Drop and recreate database
+-- WARNING: this script is intended for first-time MariaDB volume init only.
+-- The `mariadb-init` directory is executed by the official MariaDB image
+-- exclusively when the data directory is empty, so it is safe in that
+-- context. Do NOT run this manually against a populated volume — it will
+-- DROP the metrics database and wipe all historical data.
 DROP DATABASE IF EXISTS metrics;
 CREATE DATABASE metrics;
 CREATE USER IF NOT EXISTS 'metrics'@'%' IDENTIFIED BY 'metrics';


### PR DESCRIPTION
## Summary
Follow-up to #53 — two minor cleanups that were noted in review but not blocking the merge:

- **`MetricsCalculator.calculate_daily_metrics`** — hoist the loop-invariant `if user and ai_responses:` check out of the per-AI-response loop. The user-token attribution now multiplies by `len(ai_responses)` once instead of repeating the test on every iteration. Behaviour is unchanged: when there are no AI responses or no user, nothing is added; otherwise the user receives `token_count × N` input tokens (matching the existing regeneration semantics).
- **`mariadb-init/init.sql`** — add a comment clarifying that the leading `DROP DATABASE IF EXISTS` is only safe because the official MariaDB image runs `mariadb-init` scripts exclusively on first volume init. Anyone tempted to `mysql < init.sql` against a populated volume would wipe their historical metrics; the warning makes that explicit.

`delete_future_dates()` — flagged in review as defined-but-unused — was already removed during the merge, so no action needed there.

The `.env`-vs-`.env.example` convention discussion was deliberately left out; that's a wider call.