### PR TITLE
fix: split rating feedback tags by thumbsUp/thumbsDown direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,11 +312,11 @@ librechat_thumbs_down_per_model{model="claude-3"} 2.0
 librechat_rating_ratio_per_model{model="gpt-4"} 88.9
 librechat_rating_ratio_per_model{model="claude-3"} 77.8
 
-# HELP librechat_rating_counts_per_tag Number of ratings per feedback tag
+# HELP librechat_rating_counts_per_tag Number of ratings per feedback tag and rating direction
 # TYPE librechat_rating_counts_per_tag gauge
-librechat_rating_counts_per_tag{tag="accurate_reliable"} 8.0
-librechat_rating_counts_per_tag{tag="helpful"} 6.0
-librechat_rating_counts_per_tag{tag="creative"} 4.0
+librechat_rating_counts_per_tag{tag="accurate_reliable",rating="thumbsUp"} 8.0
+librechat_rating_counts_per_tag{tag="clear_well_written",rating="thumbsUp"} 6.0
+librechat_rating_counts_per_tag{tag="not_matched",rating="thumbsDown"} 4.0
 
 # HELP librechat_overall_rating_ratio Overall percentage of positive ratings (0-100)
 # TYPE librechat_overall_rating_ratio gauge
@@ -337,11 +337,11 @@ librechat_rated_messages_total 18.0
 # HELP librechat_model_tag_thumbs_up Number of thumbs up ratings per model and tag combination
 # TYPE librechat_model_tag_thumbs_up gauge
 librechat_model_tag_thumbs_up{model="gpt-4",tag="accurate_reliable"} 5.0
-librechat_model_tag_thumbs_up{model="claude-3",tag="creative"} 3.0
+librechat_model_tag_thumbs_up{model="claude-3",tag="creative_solution"} 3.0
 
 # HELP librechat_model_tag_thumbs_down Number of thumbs down ratings per model and tag combination
 # TYPE librechat_model_tag_thumbs_down gauge
-librechat_model_tag_thumbs_down{model="gpt-4",tag="unhelpful"} 1.0
+librechat_model_tag_thumbs_down{model="gpt-4",tag="not_helpful"} 1.0
 # HELP librechat_tool_calls_total Total number of tool calls made
 # TYPE librechat_tool_calls_total gauge
 librechat_tool_calls_total 240.0

--- a/metrics.py
+++ b/metrics.py
@@ -964,14 +964,23 @@ class LibreChatMetricsCollector(Collector):
                 cache['per_model'][model][rating] = item['count']
                 cache['per_model'][model]['total'] += item['count']
 
-            # Query 3: Per-tag ratings
+            # Query 3: Per-tag ratings, split by rating direction.
+            # Each LibreChat feedback tag belongs to exactly one rating
+            # (thumbsUp/thumbsDown), so grouping by both keeps positive and
+            # negative tags from being collapsed into a single count.
             per_tag_pipeline = [
                 {"$match": {"feedback.tag": {"$exists": True, "$ne": None}}},
-                {"$group": {"_id": "$feedback.tag", "count": {"$sum": 1}}}
+                {
+                    "$group": {
+                        "_id": {"tag": "$feedback.tag", "rating": "$feedback.rating"},
+                        "count": {"$sum": 1}
+                    }
+                }
             ]
             for item in self.messages_collection.aggregate(per_tag_pipeline):
-                tag = item['_id'] or 'unknown'
-                cache['per_tag'][tag] = item['count']
+                tag = item['_id']['tag'] or 'unknown'
+                rating = item['_id'].get('rating') or 'unknown'
+                cache['per_tag'][(tag, rating)] = item['count']
 
             # Query 4: Model-tag combinations
             model_tag_pipeline = [
@@ -1134,13 +1143,13 @@ class LibreChatMetricsCollector(Collector):
 
             metric = GaugeMetricFamily(
                 "librechat_rating_counts_per_tag",
-                "Number of ratings per feedback tag",
-                labels=["tag"],
+                "Number of ratings per feedback tag and rating direction",
+                labels=["tag", "rating"],
             )
 
-            for tag, count in data.items():
-                metric.add_metric([tag], count)
-                logger.debug("Rating count for tag %s: %s", tag, count)
+            for (tag, rating), count in data.items():
+                metric.add_metric([tag, rating], count)
+                logger.debug("Rating count for tag %s (%s): %s", tag, rating, count)
 
             yield metric
         except Exception as e:

--- a/prometheus-dev/Grafana-Dashboard-template.json
+++ b/prometheus-dev/Grafana-Dashboard-template.json
@@ -435,9 +435,37 @@
       ]
     },
     {
+      "type": "bargauge",
+      "title": "Positive Feedback Tags",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 39 },
+      "id": 27,
+      "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "showUnfilled": true },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "continuous-GrYlRd" }, "unit": "short" }
+      },
+      "targets": [
+        { "expr": "librechat_rating_counts_per_tag{rating=\"thumbsUp\"}", "legendFormat": "{{tag}}", "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" } }
+      ]
+    },
+    {
+      "type": "bargauge",
+      "title": "Negative Feedback Tags",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 39 },
+      "id": 28,
+      "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "showUnfilled": true },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "continuous-RdYlGr" }, "unit": "short" }
+      },
+      "targets": [
+        { "expr": "librechat_rating_counts_per_tag{rating=\"thumbsDown\"}", "legendFormat": "{{tag}}", "refId": "A", "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" } }
+      ]
+    },
+    {
       "type": "row",
       "title": "Tools & Files",
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 47 },
       "id": 103,
       "collapsed": false,
       "panels": []
@@ -446,7 +474,7 @@
       "type": "stat",
       "title": "Tool Calls (total)",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 40 },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 48 },
       "id": 21,
       "options": {
         "colorMode": "value",
@@ -466,7 +494,7 @@
       "type": "stat",
       "title": "Tool Errors (total)",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 40 },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 48 },
       "id": 22,
       "options": {
         "colorMode": "value",
@@ -486,7 +514,7 @@
       "type": "stat",
       "title": "Active Tool Users",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 40 },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 48 },
       "id": 23,
       "options": {
         "colorMode": "value",
@@ -506,7 +534,7 @@
       "type": "stat",
       "title": "Uploaded Files",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 40 },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 48 },
       "id": 24,
       "options": {
         "colorMode": "value",
@@ -526,7 +554,7 @@
       "type": "bargauge",
       "title": "Tool Calls per Tool",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 44 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 52 },
       "id": 25,
       "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "showUnfilled": true },
       "fieldConfig": {
@@ -540,7 +568,7 @@
       "type": "bargauge",
       "title": "Tool Success Rate per Tool",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 44 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 52 },
       "id": 26,
       "options": { "orientation": "horizontal", "displayMode": "gradient", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "showUnfilled": true },
       "fieldConfig": {


### PR DESCRIPTION
Closes #64.

## Problem

The rating tags were out of sync with positive/negative feedback. LibreChat stores feedback as `{ rating, tag }`, and each feedback tag belongs to exactly one rating direction (verified against production: `accurate_reliable`→thumbsUp, `not_matched`→thumbsDown, etc.). But the per-tag metric grouped on `feedback.tag` alone, discarding the rating direction — so in Grafana there was no way to separate positive from negative feedback tags.

The README also documented tags (`helpful`, `creative`, `unhelpful`) that no longer exist in current LibreChat.

## Changes

- **metrics.py**: Query 3 now groups by `{tag, rating}`, and `librechat_rating_counts_per_tag` gains a `rating="thumbsUp|thumbsDown"` label.
- **README.md**: example metrics updated to the real current LibreChat tag keys and the new `rating` label.
- **prometheus-dev/Grafana-Dashboard-template.json**: added "Positive Feedback Tags" and "Negative Feedback Tags" panels using the new label; shifted the Tools & Files row to make room.

## Compatibility note

This adds a label to an existing metric. Queries on `librechat_rating_counts_per_tag{tag="..."}` keep working, but recording rules/alerts that assumed no `rating` label will now see series split by rating direction.

## Verification

- Confirmed the real `{tag, rating}` distribution and that `feedback.tag` is a plain string key against the production LibreChat MongoDB.
- Metric renders correct Prometheus exposition format with the real data.
- Dashboard JSON validated; `metrics.py` compiles and passes flake8 F/E9 checks.