### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,4 +67,4 @@ jobs:
         run: cat exporter.log
 
       - name: probe for valid output
-        run: grep 'librechat_registered_users 1.0' metrics || grep 'librechat_registered_users_total' metrics
+        run: grep 'librechat_registered_users_total 1.0' metrics


### PR DESCRIPTION
This patch essentially reverts/replaces 3afb7c83. The patch caused old metrics to still be a valid test output (they shouldn't) while not testing for the actual value of the new output. Now it tests for the correct value of a specific metrics name.