### PR TITLE
Update CI matrix to Python 3.10–3.14 and ubuntu-slim

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,17 +8,17 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       matrix:
         # https://endoflife.date/python
         # https://github.com/actions/runner-images
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
         # https://endoflife.date/python
         # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#python
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
       - name: start mongodb
@@ -32,8 +32,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - run: pip install -r requirements.txt
-
-      - run: pip install flake8 bandit
 
       - name: add test data to mongodb
         run: |


### PR DESCRIPTION
Drop Python 3.9, which reached end-of-life in October 2024, and add 3.14 to keep coverage on the current release. Switch the lint runner to ubuntu-slim to reduce image pull time. Remove the stale `pip install flake8 bandit` step from the integration test workflow — neither tool was ever invoked there; linting and security scanning remain in the dedicated lint workflow.