### PR TITLE
Disable cache in CI to avoid intermittent metric warm-up failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
         env:
           MONGODB_URI: "mongodb://127.0.0.1:27017/"
           LOGGING_LEVEL: debug
+          METRICS_CACHE_ENABLED: "false"
         run: python metrics.py &> exporter.log &
 
       - name: get metrics


### PR DESCRIPTION
The integration test would occasionally fail because curl stopped retrying once the HTTP server returned 200, even though the cache was still warming up and the response body was empty. Disabling the cache in CI makes metrics available on the first scrape, eliminating the race between the background collection thread and the curl retry loop.

This fixes #72