### PR TITLE
Fix tool-error metrics crash on Azure Cosmos DB ($regexMatch 51104)

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -1364,9 +1364,28 @@ class LibreChatMetricsCollector(Collector):
             # ── Query B (all-time): error counts per tool
             # $regexMatch with options:"i" matches both capitalised and lowercase
             # variants emitted by LibreChat (ToolService.js vs assistants/chatV1.js).
-            # $convert guards against non-string output values (objects, numbers)
-            # that would cause $regexMatch to throw.
+            # An explicit $type guard ensures $regexMatch only ever sees a string;
+            # non-string outputs (structured objects, numbers) are mapped to "".
+            # We avoid $convert coercion because Azure Cosmos DB / DocumentDB do not
+            # take its onError branch for unsupported types, leaking a non-string
+            # value into $regexMatch (error 51104). See issue #67.
             error_regex = "error processing tool"
+
+            def error_match(field):
+                return {
+                    "$regexMatch": {
+                        "input": {
+                            "$cond": [
+                                {"$eq": [{"$type": field}, "string"]},
+                                field,
+                                ""
+                            ]
+                        },
+                        "regex": error_regex,
+                        "options": "i"
+                    }
+                }
+
             errors_pipeline = [
                 {"$match": has_tool_call},
                 {
@@ -1378,18 +1397,7 @@ class LibreChatMetricsCollector(Collector):
                                 "cond": {
                                     "$and": [
                                         {"$eq": ["$$c.type", "tool_call"]},
-                                        {
-                                            "$regexMatch": {
-                                                "input": {"$convert": {
-                                                    "input": "$$c.tool_call.output",
-                                                    "to": "string",
-                                                    "onError": "",
-                                                    "onNull": ""
-                                                }},
-                                                "regex": error_regex,
-                                                "options": "i"
-                                            }
-                                        }
+                                        error_match("$$c.tool_call.output")
                                     ]
                                 }
                             }
@@ -1437,18 +1445,7 @@ class LibreChatMetricsCollector(Collector):
                         "error_count": {
                             "$sum": {
                                 "$cond": [
-                                    {
-                                        "$regexMatch": {
-                                            "input": {"$convert": {
-                                                "input": "$_tc.tool_call.output",
-                                                "to": "string",
-                                                "onError": "",
-                                                "onNull": ""
-                                            }},
-                                            "regex": error_regex,
-                                            "options": "i"
-                                        }
-                                    },
+                                    error_match("$_tc.tool_call.output"),
                                     1,
                                     0
                                 ]


### PR DESCRIPTION
`_fetch_all_tool_metrics` crashes on every collection cycle on Azure Cosmos DB for MongoDB (and DocumentDB) with:

```
The $regexMatch requires that the 'input' parameter must be of type string. (code 51104)
```

### Root cause
The tool-error pipelines guarded `$regexMatch` by coercing `tool_call.output` with `$convert ... onError: "" onNull: ""`. On genuine MongoDB, converting an unsupported input type (a structured object/array — exactly what `tool_call.output` is for errors) takes the `onError` branch and yields a string. On Cosmos DB / DocumentDB the `onError` branch is **not** taken, so the non-string value reaches `$regexMatch`, which rejects it (51104) and aborts the entire collection cycle.

### Fix
Drop the `$convert` coercion and gate the regex on an explicit `$type` check, feeding `$regexMatch` the string output or an empty string otherwise. Extracted into a shared `error_match()` helper so the all-time and 5-minute pipelines stay in sync.

Behavior is unchanged on MongoDB (non-string outputs still map to `""`); the pipeline is now portable across MongoDB, Cosmos DB, and DocumentDB.

`flake8 --max-line-length 120` and `bandit` pass clean.

Fixes #67