### PR TITLE
Support configurable timezone for daily/weekly/monthly metric boundaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
           LOGGING_LEVEL: debug
           METRICS_CACHE_ENABLED: "false"
           LIBRECHAT_URL: "http://localhost:8000"
+          METRICS_TIMEZONE: "Asia/Tokyo"
         run: python metrics.py &> exporter.log &
 
       - name: get metrics

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ LOGGING_FORMAT="%(asctime)s - %(levelname)s - %(message)s"
 # Specify Mongo Database - Optional. Defaults to "LibreChat"
 MONGODB_DATABASE=librechat
 
+# Timezone for daily/weekly/monthly metric boundaries - Optional. Defaults to "UTC".
+# Accepts an IANA timezone name (e.g. Asia/Tokyo, Europe/Berlin) so the
+# daily/weekly/monthly unique-user metrics reset at local midnight instead of
+# UTC midnight. An invalid value logs a warning and falls back to UTC.
+METRICS_TIMEZONE=UTC
+
 # ===== Performance Optimization =====
 # Background cache enabled (recommended for large databases)
 # When enabled, metrics are collected in a background thread and cached

--- a/metrics.py
+++ b/metrics.py
@@ -5,6 +5,7 @@ import time
 import urllib.error
 import urllib.request
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from dotenv import load_dotenv
 from prometheus_client.core import REGISTRY, GaugeMetricFamily, CounterMetricFamily
@@ -78,6 +79,20 @@ class LibreChatMetricsCollector(Collector):
 
         self.librechat_url = os.getenv("LIBRECHAT_URL", "")
         logger.info("LibreChat URL (health check): %s", self.librechat_url or "(not configured)")
+
+        # Timezone for daily/weekly/monthly calendar boundaries. Defaults to UTC.
+        # createdAt is stored as UTC; computing boundaries as tz-aware datetimes in
+        # the configured zone lets PyMongo serialize them back to the correct UTC
+        # instant, so the only effect is *where* the local day/week/month begins.
+        tz_name = os.getenv("METRICS_TIMEZONE", "UTC")
+        try:
+            self.timezone = ZoneInfo(tz_name)
+        except (ZoneInfoNotFoundError, ValueError) as e:
+            logger.warning(
+                "Invalid METRICS_TIMEZONE %r (%s); falling back to UTC", tz_name, e
+            )
+            self.timezone = timezone.utc
+        logger.info("Metrics timezone (daily/weekly/monthly boundaries): %s", self.timezone)
 
         logger.info("Cache configuration:")
         logger.info("  Cache enabled: %s", self.cache_enabled)
@@ -597,14 +612,18 @@ class LibreChatMetricsCollector(Collector):
         except Exception as e:
             logger.exception("Error collecting number of registered users: %s", e)
 
+    def _start_of_day(self):
+        """Return the start of the current day (00:00) in the configured timezone."""
+        return datetime.now(self.timezone).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+
     def collect_daily_unique_users(self):
         """
         Collect number of unique users active in the current day.
         """
         try:
-            start_of_day = datetime.now(timezone.utc).replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
+            start_of_day = self._start_of_day()
             unique_users = len(
                 self.messages_collection.distinct(
                     "user", {"createdAt": {"$gte": start_of_day}}
@@ -624,13 +643,9 @@ class LibreChatMetricsCollector(Collector):
         Collect number of unique users active in the current week (starting from Monday).
         """
         try:
-            now = datetime.now(timezone.utc)
-            # Calculate days since Monday (0=Monday, 1=Tuesday, etc.)
-            days_since_monday = now.weekday()
-            # Get the start of current week (Monday 00:00:00)
-            start_of_week = (now - timedelta(days=days_since_monday)).replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
+            # Calculate days since Monday (0=Monday, 1=Tuesday, etc.) in local time
+            start_of_day = self._start_of_day()
+            start_of_week = start_of_day - timedelta(days=start_of_day.weekday())
 
             unique_users = len(
                 self.messages_collection.distinct(
@@ -651,11 +666,8 @@ class LibreChatMetricsCollector(Collector):
         Collect number of unique users active in the current month.
         """
         try:
-            now = datetime.now(timezone.utc)
-            # Get the start of current month (1st day 00:00:00)
-            start_of_month = now.replace(
-                day=1, hour=0, minute=0, second=0, microsecond=0
-            )
+            # Get the start of current month (1st day 00:00:00) in local time
+            start_of_month = self._start_of_day().replace(day=1)
 
             unique_users = len(
                 self.messages_collection.distinct(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 Twisted
 mysql-connector-python
 python-dateutil
+tzdata


### PR DESCRIPTION
## Problem

Daily, weekly, and monthly unique-user metrics derive their calendar boundaries from **UTC** midnight. For organizations in non-UTC zones this misaligns daily reporting with the local business day — e.g. in JST (`Asia/Tokyo`), UTC 00:00 = JST 09:00, so the "daily" window resets at 09:00 local time.

## Change

- New optional env var **`METRICS_TIMEZONE`** accepting an IANA name (e.g. `Asia/Tokyo`, `Europe/Berlin`). **Defaults to `UTC`**, so existing deployments are byte-for-byte unchanged.
- Boundaries (`collect_daily_unique_users`, `collect_weekly_unique_users`, `collect_monthly_unique_users`) are computed as timezone-aware datetimes in the configured zone via a shared `_start_of_day()` helper. `createdAt` is stored as UTC, so PyMongo serializes the aware boundaries back to the correct UTC instant — only *where* the local day/week/month begins changes. Week still starts Monday (in local time).
- Invalid/unknown `METRICS_TIMEZONE` logs a warning and falls back to UTC (never crashes the collector).
- `tzdata` added to `requirements.txt` so IANA zones resolve on the `python:3.14-slim` base image, which ships no system zoneinfo DB.
- README documents the new variable; the integration workflow now runs with `METRICS_TIMEZONE: Asia/Tokyo` to exercise the non-UTC path.

## Scope

Only the three calendar-boundary metrics are affected. 5-minute windows and all-time totals are unchanged.

`flake8 --max-line-length 120` and `bandit` pass clean; boundary math verified for Asia/Tokyo (local midnight → UTC 15:00 prior day), Monday week start, 1st-of-month, and invalid-zone fallback.

Fixes #66