### PR TITLE
Add Helm chart for Kubernetes deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,21 @@ metrics:
 
 Make sure the networks attribute is the same as your mongodb container.
 
+## Kubernetes / Helm
+
+A Helm chart is provided under [`charts/librechat-exporter`](charts/librechat-exporter)
+for deploying the exporter to Kubernetes. It ships a Deployment and Service and
+can optionally create a Prometheus Operator `ServiceMonitor`.
+
+```sh
+helm install librechat-exporter ./charts/librechat-exporter \
+  --set mongodb.uri="mongodb://my-mongo:27017/" \
+  --set serviceMonitor.enabled=true
+```
+
+See the [chart README](charts/librechat-exporter/README.md) for the full list of
+values.
+
 ## Metrics
 
 The exporter provides the following metrics specific to LibreChat:

--- a/charts/librechat-exporter/.helmignore
+++ b/charts/librechat-exporter/.helmignore
@@ -1,0 +1,10 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+*.tmproj
+*.bak
+*.orig
+*~
+.vscode/
+.idea/

--- a/charts/librechat-exporter/Chart.yaml
+++ b/charts/librechat-exporter/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: librechat-exporter
+description: Prometheus exporter for LibreChat metrics from MongoDB
+type: application
+# Chart version — bump on every chart change.
+version: 0.1.0
+# Version of the librechat_exporter image this chart deploys by default.
+appVersion: "2.4.0"
+home: https://github.com/virtUOS/librechat_exporter
+sources:
+  - https://github.com/virtUOS/librechat_exporter
+keywords:
+  - librechat
+  - prometheus
+  - exporter
+  - metrics
+  - mongodb
+maintainers:
+  - name: virtUOS
+    url: https://github.com/virtUOS

--- a/charts/librechat-exporter/README.md
+++ b/charts/librechat-exporter/README.md
@@ -1,0 +1,73 @@
+# librechat-exporter Helm chart
+
+Deploys the [LibreChat Prometheus exporter](https://github.com/virtUOS/librechat_exporter)
+to Kubernetes: a single Deployment that reads metrics from MongoDB and exposes
+them on port `8000` at `/metrics`.
+
+## Installing
+
+```sh
+helm install librechat-exporter ./charts/librechat-exporter \
+  --set mongodb.uri="mongodb://my-mongo:27017/"
+```
+
+By default the chart creates a Secret holding the MongoDB URI. To reference an
+existing Secret instead:
+
+```sh
+helm install librechat-exporter ./charts/librechat-exporter \
+  --set mongodb.existingSecret=my-secret \
+  --set mongodb.existingSecretKey=mongodb-uri
+```
+
+## Prometheus scraping
+
+The chart always creates a `Service`. To have the Prometheus Operator scrape it,
+enable the `ServiceMonitor` (requires the `monitoring.coreos.com` CRDs):
+
+```sh
+helm install librechat-exporter ./charts/librechat-exporter \
+  --set serviceMonitor.enabled=true
+```
+
+Without the operator, scrape the Service directly or add
+`prometheus.io/scrape` annotations via `service.annotations`.
+
+## Configuration
+
+The exporter is configured entirely through environment variables. Set them via
+the `env` map (simple values) or `extraEnv` (raw entries with `valueFrom`).
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `replicaCount` | `1` | Number of exporter replicas |
+| `image.repository` | `ghcr.io/virtuos/librechat_exporter` | Image repository |
+| `image.tag` | `""` (chart `appVersion`) | Image tag |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
+| `imagePullSecrets` | `[]` | Image pull secrets |
+| `mongodb.uri` | `mongodb://mongodb:27017/` | MongoDB URI (used when `existingSecret` is empty) |
+| `mongodb.existingSecret` | `""` | Existing Secret holding the MongoDB URI |
+| `mongodb.existingSecretKey` | `mongodb-uri` | Key within `existingSecret` |
+| `env` | `{}` | Extra env vars as a name/value map (e.g. `METRICS_TIMEZONE`, `LOGGING_LEVEL`, `ENABLE_*`, `LIBRECHAT_URL`) |
+| `extraEnv` | `[]` | Extra env vars as raw entries (`valueFrom`, etc.) |
+| `service.type` | `ClusterIP` | Service type |
+| `service.port` | `8000` | Service port |
+| `service.annotations` | `{}` | Service annotations |
+| `serviceMonitor.enabled` | `false` | Create a Prometheus Operator ServiceMonitor |
+| `serviceMonitor.interval` | `60s` | Scrape interval |
+| `serviceMonitor.scrapeTimeout` | `""` | Scrape timeout |
+| `serviceMonitor.labels` | `{}` | Extra ServiceMonitor labels (e.g. to match a Prometheus release) |
+| `serviceMonitor.honorLabels` | `false` | Honor labels on scrape |
+| `serviceMonitor.relabelings` | `[]` | Endpoint relabelings |
+| `serviceMonitor.metricRelabelings` | `[]` | Metric relabelings |
+| `serviceAccount.create` | `true` | Create a ServiceAccount |
+| `serviceAccount.name` | `""` | ServiceAccount name (generated when empty) |
+| `serviceAccount.annotations` | `{}` | ServiceAccount annotations |
+| `livenessProbe` / `readinessProbe` | `httpGet /metrics` | Probe configuration |
+| `resources` | `{}` | Container resource requests/limits |
+| `podAnnotations` / `podLabels` | `{}` | Extra pod metadata |
+| `podSecurityContext` / `securityContext` | `{}` | Security contexts |
+| `nodeSelector` / `tolerations` / `affinity` | `{}` / `[]` / `{}` | Scheduling controls |
+
+See the exporter's main [README](../../README.md) for the full list of supported
+environment variables.

--- a/charts/librechat-exporter/templates/NOTES.txt
+++ b/charts/librechat-exporter/templates/NOTES.txt
@@ -1,0 +1,23 @@
+{{ include "librechat-exporter.fullname" . }} has been deployed.
+
+The exporter serves Prometheus metrics on port {{ .Values.service.port }} at /metrics.
+
+To scrape it from within the cluster:
+
+  http://{{ include "librechat-exporter.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/metrics
+
+{{- if .Values.serviceMonitor.enabled }}
+
+A ServiceMonitor was created. Ensure your Prometheus Operator's
+serviceMonitorSelector matches this chart's labels (override
+serviceMonitor.labels if needed).
+{{- else }}
+
+ServiceMonitor is disabled. Enable it with --set serviceMonitor.enabled=true
+(requires the Prometheus Operator CRDs), or scrape the Service directly.
+{{- end }}
+
+To verify locally:
+
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "librechat-exporter.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  curl http://localhost:{{ .Values.service.port }}/metrics

--- a/charts/librechat-exporter/templates/_helpers.tpl
+++ b/charts/librechat-exporter/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/* Expand the name of the chart. */}}
+{{- define "librechat-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Create a fully qualified app name. */}}
+{{- define "librechat-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Chart name and version label. */}}
+{{- define "librechat-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Common labels. */}}
+{{- define "librechat-exporter.labels" -}}
+helm.sh/chart: {{ include "librechat-exporter.chart" . }}
+{{ include "librechat-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* Selector labels. */}}
+{{- define "librechat-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "librechat-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Service account name. */}}
+{{- define "librechat-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "librechat-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/* Name of the Secret holding the MongoDB URI. */}}
+{{- define "librechat-exporter.mongodbSecretName" -}}
+{{- if .Values.mongodb.existingSecret }}
+{{- .Values.mongodb.existingSecret }}
+{{- else }}
+{{- include "librechat-exporter.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/* Key within the MongoDB Secret. */}}
+{{- define "librechat-exporter.mongodbSecretKey" -}}
+{{- if .Values.mongodb.existingSecret }}
+{{- .Values.mongodb.existingSecretKey }}
+{{- else }}
+{{- "mongodb-uri" }}
+{{- end }}
+{{- end }}

--- a/charts/librechat-exporter/templates/deployment.yaml
+++ b/charts/librechat-exporter/templates/deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "librechat-exporter.fullname" . }}
+  labels:
+    {{- include "librechat-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "librechat-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "librechat-exporter.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "librechat-exporter.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "librechat-exporter.mongodbSecretName" . }}
+                  key: {{ include "librechat-exporter.mongodbSecretKey" . }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/librechat-exporter/templates/secret.yaml
+++ b/charts/librechat-exporter/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.mongodb.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "librechat-exporter.fullname" . }}
+  labels:
+    {{- include "librechat-exporter.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  mongodb-uri: {{ required "mongodb.uri is required when mongodb.existingSecret is not set" .Values.mongodb.uri | quote }}
+{{- end }}

--- a/charts/librechat-exporter/templates/service.yaml
+++ b/charts/librechat-exporter/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "librechat-exporter.fullname" . }}
+  labels:
+    {{- include "librechat-exporter.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: metrics
+      port: {{ .Values.service.port }}
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    {{- include "librechat-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/librechat-exporter/templates/serviceaccount.yaml
+++ b/charts/librechat-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "librechat-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "librechat-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/librechat-exporter/templates/servicemonitor.yaml
+++ b/charts/librechat-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "librechat-exporter.fullname" . }}
+  labels:
+    {{- include "librechat-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "librechat-exporter.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/librechat-exporter/values.yaml
+++ b/charts/librechat-exporter/values.yaml
@@ -1,0 +1,85 @@
+# Default values for librechat-exporter.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/virtuos/librechat_exporter
+  # Overrides the image tag. Defaults to the chart's appVersion when empty.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+mongodb:
+  # MongoDB connection URI. Used to populate a chart-managed Secret when
+  # existingSecret is empty.
+  uri: "mongodb://mongodb:27017/"
+  # Name of an existing Secret that contains the MongoDB URI. When set, the
+  # chart does not create its own Secret and `uri` above is ignored.
+  existingSecret: ""
+  # Key within existingSecret that holds the MongoDB URI.
+  existingSecretKey: mongodb-uri
+
+# Additional environment variables as a simple name/value map. The exporter
+# is configured entirely through env vars, e.g.:
+#   METRICS_TIMEZONE: "Asia/Tokyo"
+#   LOGGING_LEVEL: "info"
+#   ENABLE_TOOL_METRICS: "false"
+#   LIBRECHAT_URL: "http://librechat:3080"
+env: {}
+
+# Additional environment variables as raw entries, for valueFrom and friends.
+# Example:
+#   - name: EXTRA
+#     valueFrom:
+#       configMapKeyRef:
+#         name: my-config
+#         key: extra
+extraEnv: []
+
+service:
+  type: ClusterIP
+  port: 8000
+  annotations: {}
+
+serviceMonitor:
+  # Requires the Prometheus Operator CRDs (monitoring.coreos.com) to be installed.
+  enabled: false
+  # Scrape interval. Defaults to 60s, matching the exporter's collection cadence.
+  interval: 60s
+  scrapeTimeout: ""
+  # Extra labels for the ServiceMonitor (e.g. to match a Prometheus release selector).
+  labels: {}
+  honorLabels: false
+  relabelings: []
+  metricRelabelings: []
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# Probes hit /metrics, which always returns 200 (empty during cache warm-up).
+livenessProbe:
+  httpGet:
+    path: /metrics
+    port: metrics
+  initialDelaySeconds: 10
+  periodSeconds: 30
+readinessProbe:
+  httpGet:
+    path: /metrics
+    port: metrics
+  initialDelaySeconds: 5
+  periodSeconds: 15
+
+resources: {}
+podAnnotations: {}
+podLabels: {}
+podSecurityContext: {}
+securityContext: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
Adds a Helm chart under `charts/librechat-exporter` so the exporter can be deployed to Kubernetes and referenced from the official LibreChat chart (per #32).

## What's included

- **Deployment + Service** — single replica, image `ghcr.io/virtuos/librechat_exporter` (tag defaults to the chart `appVersion`), `/metrics` on port 8000, readiness/liveness probes on `/metrics`.
- **MongoDB config** — `mongodb.uri` rendered into a chart-managed Secret, or point at an `existingSecret`/`existingSecretKey`.
- **Exporter env** — every exporter variable is configurable via an `env` name/value map (e.g. `METRICS_TIMEZONE`, `ENABLE_*`, `LIBRECHAT_URL`) plus an `extraEnv` raw list for `valueFrom`.
- **Optional ServiceMonitor** — gated behind `serviceMonitor.enabled` (Prometheus Operator CRDs), with configurable interval/labels/relabelings.
- **ServiceAccount, resources, scheduling, security contexts** — standard values hooks.
- Chart `README.md` documenting all values; the main README gains a Helm section linking to it.

## Validation

`helm lint` (and `--strict`) pass. `helm template` renders cleanly across default, `existingSecret`, `serviceMonitor.enabled=true`, and `serviceAccount.create=false` scenarios; rendered manifests parse as valid YAML; the `required` guard correctly fails when no MongoDB URI source is configured.

Scope per discussion: chart source only — no packaging/publishing workflow in this PR.

Closes #32