### PR TITLE
Add CI concurrency groups and fix spurious cancelled-run failures

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,12 @@ on:
       - "dependabot/**"
   pull_request:
 
+# Cancel superseded runs of the same workflow on the same ref (e.g. after a
+# force-push) so stale runs do not linger.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-slim

--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -3,6 +3,12 @@ name: Publish Docker image
 on:
   push:
 
+# Cancel superseded builds on the same ref (e.g. after a force-push) so only
+# the latest commit is built and published.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   push_to_registries:
     name: Push Docker image to multiple registries

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,13 @@ on:
       - "dependabot/**"
   pull_request:
 
+# Cancel superseded runs of the same workflow on the same ref (e.g. after a
+# force-push), so an in-progress run does not linger and surface as a spurious
+# failure. push and pull_request runs for the same commit remain independent.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -59,13 +66,16 @@ jobs:
           curl -fisS --retry 60 --retry-delay 1 --retry-all-errors
           http://localhost:8000 -o metrics
 
+      # Debug helpers — tolerate a missing file so a cancelled run is not
+      # flipped to "failure" by these always() steps when the metrics file
+      # was never written.
       - name: show metrics
         if: ${{ always() }}
-        run: cat metrics
+        run: cat metrics || true
 
       - name: show log
         if: ${{ always() }}
-        run: cat exporter.log
+        run: cat exporter.log || true
 
       - name: probe for valid output
         run: grep 'librechat_registered_users_total 1.0' metrics


### PR DESCRIPTION
## Problem

Each commit on a branch with an open PR triggers the `Integration tests` workflow twice (`push` and `pull_request`). When one run is superseded/cancelled (e.g. after a force-push), its `if: always()` debug steps still run, `cat metrics` on a file that was never written exits 1, and the run flips from **cancelled** to **failure** — a red X on the PR for the exact same SHA that the sibling run passed. (Observed on #69 during this branch's history.)

## Fix

- Add a `concurrency` group to all three workflows keyed by workflow + event + ref, with `cancel-in-progress: true`, so superseded runs cancel cleanly instead of lingering. `push` and `pull_request` runs for the same commit stay independent (different `event_name`).
- Make the `show metrics` / `show log` debug steps tolerate a missing file (`|| true`) so a cancelled run is never reported as a failure.

YAML validated for all three workflows.

Follow-up to the CI work merged earlier in #73/#70/#71.