### PR TITLE
chore: release 2.5.0 (chart appVersion bump)

### DIFF
--- a/charts/librechat-exporter/Chart.yaml
+++ b/charts/librechat-exporter/Chart.yaml
@@ -3,9 +3,9 @@ name: librechat-exporter
 description: Prometheus exporter for LibreChat metrics from MongoDB
 type: application
 # Chart version — bump on every chart change.
-version: 0.1.0
+version: 0.1.1
 # Version of the librechat_exporter image this chart deploys by default.
-appVersion: "2.4.0"
+appVersion: "2.5.0"
 home: https://github.com/virtUOS/librechat_exporter
 sources:
   - https://github.com/virtUOS/librechat_exporter


### PR DESCRIPTION
Bumps the Helm chart `appVersion` to 2.5.0 (and chart `version` to 0.1.1) so it deploys the 2.5.0 image by default. Prep for the 2.5.0 release tag.